### PR TITLE
Secure cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,17 @@ The cookie name is one of the following by descending order of priority:
 
 In case of HTTPS requests, cookies can be marked as secure.
 This can be configured by setting the `com.amadeus.session.cookie.secure`
-initialization parameter or system property to `true`.
+initialization parameter or system property to `true`.  
+To apply this behavior only when the request is over secured channel
+(i.e. HTTPS), set `com.amadeus.session.cookie.secure.on.secured.request`
+to `true`. In this case if request comes over insecure channel (i.e. HTTP),
+the cookie will not be marked as secure. Reason for this behavior is that
+application servers are often behind a load balancer or a TLS offloader 
+which calls them via HTTP, so even though the exchange with client is over HTTPS, application server is not aware of it. In those cases we want to force cookie to
+be marked as secure. When application server is either directly exposed
+to secured requests or are aware if request is secured via headers injected
+by TLS offloaders, this additional property allows using that capability to
+select whether cookie should be marked or not.
 
 For Servlet 3.x and later containers, cookies can be marked as HTTP only.
 This can be configured by setting `com.amadeus.session.cookie.httpOnly`

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -116,7 +116,7 @@ Verify that builds and test pass.
 Set new version for the release.
 
 ```sh
-mvn versions:set -DnewVersion=0.4.6
+mvn versions:set -DnewVersion=0.4.7
 ```
 
 Perform build with release profile to add sources and javadoc. Perform deploy to OSS Sonatype Nexus:
@@ -131,8 +131,8 @@ If release is successful, commit the version and commit and tag changes in git.
 ```sh
 mvn versions:commit
 git add *
-git commit -m "version 0.4.6"
-git tag -a v0.4.6 -m "version 0.4.6"
+git commit -m "version 0.4.7"
+git tag -a v0.4.7 -m "version 0.4.7"
 git push origin --tags
 ```
 

--- a/integration-tests/agent-tests/pom.xml
+++ b/integration-tests/agent-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amadeus.session</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4.7</version>
   </parent>
   <name>agent-tests</name>
   <packaging>jar</packaging>

--- a/integration-tests/arquillian-tests/pom.xml
+++ b/integration-tests/arquillian-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amadeus.session</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4.7</version>
   </parent>
   <packaging>jar</packaging>
   <properties>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.amadeus</groupId>
     <artifactId>session</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4.7</version>
   </parent>
   <packaging>pom</packaging>
   <name>integration-tests</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amadeus</groupId>
   <artifactId>session</artifactId>
-  <version>0.4-SNAPSHOT</version>
+  <version>0.4.7</version>
   <packaging>pom</packaging>
   <name>HttpSessionReplacer</name>
   <description>Provides management of application sessions via a session repository (e.g. Redis). General JEE container use case with HttpSession is supported.</description>

--- a/session-agent/pom.xml
+++ b/session-agent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amadeus</groupId>
     <artifactId>session</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4.7</version>
   </parent>
   <name>session-agent</name>
   <description>JVM agent that enables session support in a JEE container.</description>

--- a/session-replacement/pom.xml
+++ b/session-replacement/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.amadeus</groupId>
     <artifactId>session</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4.7</version>
   </parent>
   <name>session-replacement</name>
   <description>Implementation of session management for JEE HttpSessions and general use case. Includes implemenations of in-memory and redis session distribution.</description>

--- a/session-replacement/src/main/java/com/amadeus/session/servlet/CookieSessionTracking.java
+++ b/session-replacement/src/main/java/com/amadeus/session/servlet/CookieSessionTracking.java
@@ -54,6 +54,10 @@ class CookieSessionTracking extends BaseSessionTracking implements SessionTracki
    */
   static final String SECURE_COOKIE_PARAMETER = "com.amadeus.session.cookie.secure";
   /**
+   * Cookie should be marked as secure only if incoming request is over secure connection.
+   */
+  static final String SECURE_COOKIE_ON_SECURED_REQUEST_PARAMETER = "com.amadeus.session.cookie.secure.on.secured.request";
+  /**
    * Used to specify that cookie should be marked as HttpOnly. Those cookies are not available
    * to javascript.
    */
@@ -61,6 +65,7 @@ class CookieSessionTracking extends BaseSessionTracking implements SessionTracki
   private boolean httpOnly = true;
   private String contextPath;
   private Boolean secure;
+  private Boolean secureOnlyOnSecuredRequest;
 
   @Override
   public String retrieveId(RequestWithSession request) {
@@ -92,7 +97,7 @@ class CookieSessionTracking extends BaseSessionTracking implements SessionTracki
     }
     HttpServletRequest httpRequest = (HttpServletRequest)request;
     if (secure) {
-      cookie.setSecure(httpRequest.isSecure());
+      cookie.setSecure(secureOnlyOnSecuredRequest ? httpRequest.isSecure() : true);
     }
     cookie.setPath(cookiePath());
     ((HttpServletResponse)response).addCookie(cookie);
@@ -110,6 +115,7 @@ class CookieSessionTracking extends BaseSessionTracking implements SessionTracki
     super.configure(conf);
     httpOnly = Boolean.valueOf(conf.getAttribute(COOKIE_HTTP_ONLY_PARAMETER, "true"));
     secure = Boolean.valueOf(conf.getAttribute(SECURE_COOKIE_PARAMETER, "false"));
+    secureOnlyOnSecuredRequest = Boolean.valueOf(conf.getAttribute(SECURE_COOKIE_ON_SECURED_REQUEST_PARAMETER, "false"));
     contextPath = conf.getAttribute(COOKIE_CONTEXT_PATH_PARAMETER, null);
   }
 }

--- a/session-replacement/src/test/java/com/amadeus/session/servlet/it/AbstractITSession.java
+++ b/session-replacement/src/test/java/com/amadeus/session/servlet/it/AbstractITSession.java
@@ -4,7 +4,7 @@ import org.junit.Assume;
 import org.junit.Before;
 
 @SuppressWarnings("javadoc")
-public class AbstractITSession {
+public abstract class AbstractITSession {
 
   @Before
   public void shouldTestsRun() {

--- a/session-replacement/src/test/java/com/amadeus/session/servlet/it/ArqITSessionWithSecureCookie.java
+++ b/session-replacement/src/test/java/com/amadeus/session/servlet/it/ArqITSessionWithSecureCookie.java
@@ -1,7 +1,6 @@
 package com.amadeus.session.servlet.it;
 
 import static com.amadeus.session.servlet.it.Helpers.callWebapp;
-import static com.amadeus.session.servlet.it.Helpers.matchLines;
 import static com.amadeus.session.servlet.it.Helpers.setSessionCookie;
 import static com.amadeus.session.servlet.it.Helpers.url;
 import static org.hamcrest.CoreMatchers.not;
@@ -12,6 +11,7 @@ import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -73,8 +73,16 @@ public class ArqITSessionWithSecureCookie extends AbstractITSession {
     HttpURLConnection connection = (HttpURLConnection) urlTest.openConnection();
     setSessionCookie(connection, originalCookie);
     connection.connect();
-    List<String> cookies = connection.getHeaderFields().get("Set-Cookie");
+    List<String> cookies = toLowerCase(connection.getHeaderFields().get("Set-Cookie"));
     assertThat(cookies, hasItem(containsString("secure")));
+  }
+
+  private List<String> toLowerCase(List<String> list) {
+    ArrayList<String> result = new ArrayList<>(list.size());
+    for (String s : list) {
+      result.add(s.toLowerCase());
+    }
+    return result;
   }
 
   @RunAsClient
@@ -86,8 +94,8 @@ public class ArqITSessionWithSecureCookie extends AbstractITSession {
     HttpURLConnection connection = (HttpURLConnection) urlTest.openConnection();
     setSessionCookie(connection, originalCookie);
     connection.connect();
-    List<String> cookies = connection.getHeaderFields().get("Set-Cookie");
-    assertThat(cookies, not(hasItem(containsString("secure"))));
+    List<String> cookies = toLowerCase(connection.getHeaderFields().get("Set-Cookie"));
+    assertThat(cookies, not(hasItem(containsString(("secure")))));
   }
 
   @RunAsClient
@@ -99,7 +107,7 @@ public class ArqITSessionWithSecureCookie extends AbstractITSession {
     HttpURLConnection connection = (HttpURLConnection) urlTest.openConnection();
     setSessionCookie(connection, originalCookie);
     connection.connect();
-    List<String> cookies = connection.getHeaderFields().get("Set-Cookie");
+    List<String> cookies = toLowerCase(connection.getHeaderFields().get("Set-Cookie"));
     assertThat(cookies, not(hasItem(containsString("secure"))));
   }
 }

--- a/session-replacement/src/test/java/com/amadeus/session/servlet/it/ArqITSessionWithSecureCookie.java
+++ b/session-replacement/src/test/java/com/amadeus/session/servlet/it/ArqITSessionWithSecureCookie.java
@@ -1,0 +1,105 @@
+package com.amadeus.session.servlet.it;
+
+import static com.amadeus.session.servlet.it.Helpers.callWebapp;
+import static com.amadeus.session.servlet.it.Helpers.matchLines;
+import static com.amadeus.session.servlet.it.Helpers.setSessionCookie;
+import static com.amadeus.session.servlet.it.Helpers.url;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@SuppressWarnings("javadoc")
+public class ArqITSessionWithSecureCookie extends AbstractITSession {
+
+  private static final String SECURE_COOKIE_WEBAPP = "secure-cookie";
+
+  private static final String NON_SECURE_COOKIE_WEBAPP = "non-secure-cookie";
+  
+  private static final String SECURE_COOKIE_ON_SECURED_REQUEST_WEBAPP = "secure-cookie-on-secured-request";
+
+  @Deployment(testable = false, name = SECURE_COOKIE_WEBAPP)
+  public static WebArchive startSecure() {
+    return Helpers.createWebApp("secure-cookie.war")
+        .addClasses(SampleServlet.class)
+        .setWebXML(new StringAsset(Descriptors.create(WebAppDescriptor.class).version("3.0")
+            .getOrCreateContextParam().paramName("com.amadeus.session.cookie.secure").paramValue("true").up()
+            .exportAsString()));
+  }
+
+  @Deployment(testable = false, name = NON_SECURE_COOKIE_WEBAPP)
+  public static WebArchive startNonSecured() {
+    return Helpers.createWebApp("non-secure-cookie.war")
+        .addClasses(SampleServlet.class)
+        .setWebXML(new StringAsset(Descriptors.create(WebAppDescriptor.class).version("3.0")
+            .getOrCreateContextParam().paramName("com.amadeus.session.cookie.secure").paramValue("false").up()
+            .exportAsString()));
+  }
+
+  @Deployment(testable = false, name = SECURE_COOKIE_ON_SECURED_REQUEST_WEBAPP)
+  public static WebArchive startSecureOnSecuredRequestOnly() {
+    return Helpers.createWebApp("secure-cookie-on-secured-request.war")
+        .addClasses(SampleServlet.class)
+        .setWebXML(new StringAsset(Descriptors.create(WebAppDescriptor.class).version("3.0")
+            .getOrCreateContextParam().paramName("com.amadeus.session.cookie.secure").paramValue("true").up()
+            .getOrCreateContextParam().paramName("com.amadeus.session.cookie.secure.on.secured.request").paramValue("true").up()
+            .exportAsString()));
+  }
+
+  @RunAsClient
+  @Test
+  @OperateOnDeployment(SECURE_COOKIE_WEBAPP)
+  public void testCookieSecured(@ArquillianResource URL baseURL) throws IOException {
+    URL urlTest = url(baseURL, "TestServlet", "testSessionPropagated");
+    String originalCookie = callWebapp(urlTest);
+    HttpURLConnection connection = (HttpURLConnection) urlTest.openConnection();
+    setSessionCookie(connection, originalCookie);
+    connection.connect();
+    List<String> cookies = connection.getHeaderFields().get("Set-Cookie");
+    assertThat(cookies, hasItem(containsString("secure")));
+  }
+
+  @RunAsClient
+  @Test
+  @OperateOnDeployment(NON_SECURE_COOKIE_WEBAPP)
+  public void testCookieNotSecured(@ArquillianResource URL baseURL) throws IOException {
+    URL urlTest = url(baseURL, "TestServlet", "testSessionPropagated");
+    String originalCookie = callWebapp(urlTest);
+    HttpURLConnection connection = (HttpURLConnection) urlTest.openConnection();
+    setSessionCookie(connection, originalCookie);
+    connection.connect();
+    List<String> cookies = connection.getHeaderFields().get("Set-Cookie");
+    assertThat(cookies, not(hasItem(containsString("secure"))));
+  }
+
+  @RunAsClient
+  @Test
+  @OperateOnDeployment(SECURE_COOKIE_ON_SECURED_REQUEST_WEBAPP)
+  public void testCookieSecureOnSecuredREquest(@ArquillianResource URL baseURL) throws IOException {
+    URL urlTest = url(baseURL, "TestServlet", "testSessionPropagated");
+    String originalCookie = callWebapp(urlTest);
+    HttpURLConnection connection = (HttpURLConnection) urlTest.openConnection();
+    setSessionCookie(connection, originalCookie);
+    connection.connect();
+    List<String> cookies = connection.getHeaderFields().get("Set-Cookie");
+    assertThat(cookies, not(hasItem(containsString("secure"))));
+  }
+}


### PR DESCRIPTION
This fixes issue in #31 . New default behavior for secure flag of the cookie will be set to true if active even if the request is not over secured channel. If there is need to set it only over secured channel, a new property is added as described in README.md