### PR TITLE
Bugfix/isRequestedSessionIdFromCookie is always returning false

### DIFF
--- a/session-replacement/src/main/java/com/amadeus/session/RequestWithSession.java
+++ b/session-replacement/src/main/java/com/amadeus/session/RequestWithSession.java
@@ -75,8 +75,10 @@ public interface RequestWithSession {
    *
    * @param id
    *          the id that has been retrieved from request.
+   * @param isFromCookie
+   *          true if the id was retrieved from a session cookie, false if it was retrieved from the URL
    */
-  void setRequestedSessionId(String id);
+  void setRequestedSessionId(String id, boolean isFromCookie);
 
   /**
    * Returns <code>true</code> if repository was checked to see if it contains

--- a/session-replacement/src/main/java/com/amadeus/session/SessionManager.java
+++ b/session-replacement/src/main/java/com/amadeus/session/SessionManager.java
@@ -254,7 +254,7 @@ public class SessionManager implements Closeable {
   public RepositoryBackedSession getSession(RequestWithSession request, boolean create, String forceId) {
     String id = retrieveId(request, forceId);
     putIdInLoggingMdc(id);
-    request.setRequestedSessionId(id);
+    request.setRequestedSessionId(id, tracking.isCookieTracking());
     RepositoryBackedSession session = null;
     if (id != null) {
       session = fetchSession(id, true);

--- a/session-replacement/src/main/java/com/amadeus/session/SessionTracking.java
+++ b/session-replacement/src/main/java/com/amadeus/session/SessionTracking.java
@@ -50,4 +50,11 @@ public interface SessionTracking {
    * @return encoded URL
    */
   String encodeUrl(RequestWithSession request, String url);
+
+  /**
+   * Tells whether the tracking is done using cookies or URL rewrite (example with ;jsessionid=... in the URL).
+   * 
+   * @return true if tracking is done with cookies, false if it is done using URL rewrite
+   */
+  boolean isCookieTracking();
 }

--- a/session-replacement/src/main/java/com/amadeus/session/servlet/CookieSessionTracking.java
+++ b/session-replacement/src/main/java/com/amadeus/session/servlet/CookieSessionTracking.java
@@ -118,4 +118,9 @@ class CookieSessionTracking extends BaseSessionTracking implements SessionTracki
     secureOnlyOnSecuredRequest = Boolean.valueOf(conf.getAttribute(SECURE_COOKIE_ON_SECURED_REQUEST_PARAMETER, "false"));
     contextPath = conf.getAttribute(COOKIE_CONTEXT_PATH_PARAMETER, null);
   }
+
+  @Override
+  public boolean isCookieTracking() {
+    return true;
+  }
 }

--- a/session-replacement/src/main/java/com/amadeus/session/servlet/HttpRequestWrapper.java
+++ b/session-replacement/src/main/java/com/amadeus/session/servlet/HttpRequestWrapper.java
@@ -30,6 +30,7 @@ class HttpRequestWrapper extends HttpServletRequestWrapper implements RequestWit
   private boolean propagated;
   private boolean idRetrieved;
   private String retrievedId;
+  private boolean isRetrievedIdFromCookie;
   private boolean repositoryChecked;
 
   /**
@@ -88,6 +89,7 @@ class HttpRequestWrapper extends HttpServletRequestWrapper implements RequestWit
 
   /**
    * Sets response associated to this request
+   *
    * @param response
    */
   public void setResponse(HttpResponseWrapper response) {
@@ -96,6 +98,7 @@ class HttpRequestWrapper extends HttpServletRequestWrapper implements RequestWit
 
   /**
    * Callback to propagate session to response.
+   *
    * @return returns <code>true</code> if session was stored
    */
   boolean propagateSession() {
@@ -202,6 +205,7 @@ class HttpRequestWrapper extends HttpServletRequestWrapper implements RequestWit
    * Get wrapped request if it is an {@link HttpRequestWrapper}.
    * Returns <code>null</code> if wrapped wrapped request was
    * not HttpRequestWrapper.
+   *
    * @return
    */
   public HttpRequestWrapper getEmbeddedRequest() {
@@ -210,6 +214,7 @@ class HttpRequestWrapper extends HttpServletRequestWrapper implements RequestWit
 
   /**
    * Returns <code>true</code> if session should be propagated on create.
+   *
    * @return
    */
   public boolean isPropagateOnCreate() {
@@ -220,10 +225,11 @@ class HttpRequestWrapper extends HttpServletRequestWrapper implements RequestWit
    * Controls if session should be propagated on create. Session should be
    * propagated on request if {@link #propagateSession()} method was called
    * (i.e. if there an event occurred that requires session propagation).
+   *
    * @param propagate
    */
   public void setPropagateOnCreate(boolean propagate) {
-    this.propagateOnCreate = propagate;
+    propagateOnCreate = propagate;
     if (embeddedRequest != null) {
       embeddedRequest.setPropagateOnCreate(true);
     }
@@ -235,17 +241,45 @@ class HttpRequestWrapper extends HttpServletRequestWrapper implements RequestWit
   }
 
   @Override
-  public void setRequestedSessionId(String id) {
+  public void setRequestedSessionId(String id, boolean isFromCookie) {
     idRetrieved = true;
     retrievedId = id;
+    isRetrievedIdFromCookie = isFromCookie;
   }
 
   @Override
   public String getRequestedSessionId() {
+    retrieveSessionId();
+    return retrievedId;
+  }
+
+  private void retrieveSessionId() {
     if (!idRetrieved) {
       getSession(false);
     }
-    return retrievedId;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromCookie() {
+    retrieveSessionId();
+    return retrievedId != null && isRetrievedIdFromCookie;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromURL() {
+    retrieveSessionId();
+    return retrievedId != null && !isRetrievedIdFromCookie;
+  }
+
+  @Override
+  public boolean isRequestedSessionIdFromUrl() {
+    return isRequestedSessionIdFromURL();
+  }
+
+  @Override
+  public boolean isRequestedSessionIdValid() {
+    retrieveSessionId();
+    return retrievedId != null && isRepositoryChecked();
   }
 
   @Override

--- a/session-replacement/src/main/java/com/amadeus/session/servlet/UrlSessionTracking.java
+++ b/session-replacement/src/main/java/com/amadeus/session/servlet/UrlSessionTracking.java
@@ -73,4 +73,9 @@ public class UrlSessionTracking extends BaseSessionTracking implements SessionTr
 
     return path + '?' + query;
   }
+
+  @Override
+  public boolean isCookieTracking() {
+    return false;
+  }
 }

--- a/session-replacement/src/test/java/com/amadeus/session/TestSessionManager.java
+++ b/session-replacement/src/test/java/com/amadeus/session/TestSessionManager.java
@@ -21,7 +21,6 @@ import org.slf4j.MDC;
 
 import com.codahale.metrics.MetricRegistry;
 
-@SuppressWarnings("javadoc")
 public class TestSessionManager {
   private ExecutorFacade executors;
   private SessionFactory factory;
@@ -60,7 +59,7 @@ public class TestSessionManager {
     RequestWithSession request = mock(RequestWithSession.class);
     when(tracking.retrieveId(request)).thenReturn("1");
     RepositoryBackedSession retrievedSession = sessionManager.getSession(request, false, null);
-    verify(request).setRequestedSessionId("1");
+    verify(request).setRequestedSessionId("1", false);
     assertEquals("Session id in Logging MDC is wrong", "1", MDC.get(configuration.getLoggingMdcKey()));
     assertSame(session, retrievedSession);
   }
@@ -69,7 +68,7 @@ public class TestSessionManager {
   public void testGetSessionNoSessionId() {
     RequestWithSession request = mock(RequestWithSession.class);
     RepositoryBackedSession retrievedSession = sessionManager.getSession(request, false, null);
-    verify(request).setRequestedSessionId(null);
+    verify(request).setRequestedSessionId(null, false);
     assertNull("Session id shouldn't be in logging MDC", MDC.get(configuration.getLoggingMdcKey()));
     assertNull(retrievedSession);
   }
@@ -103,7 +102,7 @@ public class TestSessionManager {
     when(session.getId()).thenReturn("new-id");
     when(factory.build(any(SessionData.class))).thenReturn(session);
     RepositoryBackedSession retrievedSession = sessionManager.getSession(request, true, null);
-    verify(request).setRequestedSessionId(null);
+    verify(request).setRequestedSessionId(null, false);
     verify(tracking).newId();
     assertEquals("Session id in Logging MDC is wrong", "new-id", MDC.get(configuration.getLoggingMdcKey()));
     assertSame(session, retrievedSession);

--- a/session-replacement/src/test/java/com/amadeus/session/servlet/TestHttpRequestWrapper.java
+++ b/session-replacement/src/test/java/com/amadeus/session/servlet/TestHttpRequestWrapper.java
@@ -1,7 +1,9 @@
 package com.amadeus.session.servlet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -18,7 +20,6 @@ import org.junit.Test;
 
 import com.amadeus.session.SessionManager;
 
-@SuppressWarnings("javadoc")
 public class TestHttpRequestWrapper {
 
   private static final String NEW_SESSION_ID = "11";
@@ -187,9 +188,50 @@ public class TestHttpRequestWrapper {
   public void testGetSetRequestedSessionId() {
     HttpServletRequest wrappedSimple = mock(HttpServletRequest.class);
     HttpRequestWrapper req = spy(new HttpRequestWrapper(wrappedSimple, servletContext));
-    req.setRequestedSessionId(SESSION_ID);
+    req.setRequestedSessionId(SESSION_ID, true);
     String id = req.getRequestedSessionId();
     assertEquals(SESSION_ID, id);
+    verify(req, never()).getSession(false);
+  }
+
+  @Test
+  public void testIsRequestedSessionIdValidTrue() {
+    HttpServletRequest wrappedSimple = mock(HttpServletRequest.class);
+    HttpRequestWrapper req = spy(new HttpRequestWrapper(wrappedSimple, servletContext));
+    req.setRequestedSessionId(SESSION_ID, true);
+    req.repositoryChecked();
+    assertTrue(req.isRequestedSessionIdValid());
+    verify(req, never()).getSession(false);
+  }
+
+  @Test
+  public void testIsRequestedSessionIdValidFalse() {
+    HttpServletRequest wrappedSimple = mock(HttpServletRequest.class);
+    HttpRequestWrapper req = spy(new HttpRequestWrapper(wrappedSimple, servletContext));
+    req.setRequestedSessionId(SESSION_ID, true);
+    assertFalse(req.isRequestedSessionIdValid());
+    verify(req, never()).getSession(false);
+  }
+
+  @Test
+  public void testIsRequestedSessionIdFromCookie() {
+    HttpServletRequest wrappedSimple = mock(HttpServletRequest.class);
+    HttpRequestWrapper req = spy(new HttpRequestWrapper(wrappedSimple, servletContext));
+    req.setRequestedSessionId(SESSION_ID, true);
+    assertTrue(req.isRequestedSessionIdFromCookie());
+    assertFalse(req.isRequestedSessionIdFromURL());
+    assertFalse(req.isRequestedSessionIdFromUrl());
+    verify(req, never()).getSession(false);
+  }
+
+  @Test
+  public void testIsRequestedSessionIdFromURL() {
+    HttpServletRequest wrappedSimple = mock(HttpServletRequest.class);
+    HttpRequestWrapper req = spy(new HttpRequestWrapper(wrappedSimple, servletContext));
+    req.setRequestedSessionId(SESSION_ID, false);
+    assertFalse(req.isRequestedSessionIdFromCookie());
+    assertTrue(req.isRequestedSessionIdFromURL());
+    assertTrue(req.isRequestedSessionIdFromUrl());
     verify(req, never()).getSession(false);
   }
 }


### PR DESCRIPTION
This fixes #35 and consists in:

* adding a method to SessionTracker flagging whether the tracker using session cookies or URL rewrite
* forwarding that information after a session id retrieval
* using the available completed information to reimplement the isRequestedSessionId... boolean methods of HttpServletRequest