### PR TITLE
Use ZRANGE as default expiration mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ system property or through agent arguments or through the following system prope
   initialization parameter, or using the pool configuration parameter.
 
 * `com.amadeus.session.redis.expiration`: Specifies the expiration strategy.
-  Can be `NOTIF` or `ZRANGE`. See below for explanation. Default is `NOTIF`.
+  Can be `NOTIF` or `ZRANGE`. See below for explanation. Default is `ZRANGE`.
 
 #### Session expiration
 
@@ -562,6 +562,8 @@ after the time instant when the session expires.
 This is a hardcoded value and is meant as a safety margin to complete all necessary processing.
 
 #### Notification expiration strategy
+
+__Doesn't work with Redis cluster__
 
 This strategy relies on the expired
 [keyspace notifications](http://redis.io/topics/notifications)

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -80,12 +80,12 @@ mvn verify -Predis-single, -Dredis.version=3.0
 mvn verify -Predis-single, -Dredis.image=readis:3.0
 ```
 
-By default tests use NOTIF expiration strategy, but this can be configured using
+By default tests use ZRANGE expiration strategy, but this can be configured using
 `it.com.amadeus.session.redis.expiration` system property. See expiration
 strategies for more information.
 
 ```sh
-mvn verify -Predis-single, -Dit.com.amadeus.session.redis.expiration=ZRANGE
+mvn verify -Predis-single, -Dit.com.amadeus.session.redis.expiration=NOTIF
 ```
 
 #### Redis Single Server Tests

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -216,7 +216,9 @@ Redis can be configured via `ServletContext` initialization parameters:
 </web-app>
 ```
 
-### Using NOTIF expiration strategy
+### Using NOTIF expiration strategy 
+
+__Doesn't work with redis CLUSTER__
 
 When using NOTIF expiration strategy, redis needs to be started with expiration events activated.
 That can be done either in command line:
@@ -256,9 +258,7 @@ one master goes down), other masters will be replying with CLUSTERDOWN error
 until all slots are covered (e.g. new master is elected). This will result in 
 full outage of the session storage until everything is fine. Fortunately, redis 
 cluster can be configured to give results even if there is no full coverage.
-When using NOTIF expiration strategy, all the related keys are stored on the 
-same Redis instance and we suggest to use this feature as it allows higher 
-availability.
+NOTIF expiration strategy doesn't work with cluster mode.
 
 ```
 # By default Redis Cluster nodes stop accepting queries if they detect there

--- a/session-replacement/pom.xml
+++ b/session-replacement/pom.xml
@@ -326,7 +326,7 @@
     <profile>
       <id>redis-sentinel</id>
       <properties>
-        <it.com.amadeus.session.redis.expiration>NOTIF</it.com.amadeus.session.redis.expiration>
+        <it.com.amadeus.session.redis.expiration>ZRANGE</it.com.amadeus.session.redis.expiration>
         <redis.sentinel.conf>--bind 0.0.0.0</redis.sentinel.conf>
       </properties>
       <build>

--- a/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
+++ b/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
@@ -149,7 +149,7 @@ public class RedisConfiguration {
       poolSize = conf.getAttribute(REDIS_POOL_SIZE, DEFAULT_REDIS_POOL_SIZE);
     }
     if (strategy == null) {
-      String expirationStrategy = conf.getAttribute(REDIS_EXPIRATION_STRATEGY, "NOTIF");
+      String expirationStrategy = conf.getAttribute(REDIS_EXPIRATION_STRATEGY, "ZRANGE");
       try {
         strategy = ExpirationStrategy.valueOf(expirationStrategy);
       } catch (IllegalArgumentException e) {

--- a/session-replacement/src/test/java/com/amadeus/session/TestSessionManager.java
+++ b/session-replacement/src/test/java/com/amadeus/session/TestSessionManager.java
@@ -200,7 +200,6 @@ public class TestSessionManager {
     verify(repository).getSessionData("1");
     verify(factory).build(sessionData);
     verify(session).doInvalidate(true);
-    assertEquals(1, metrics.meter(MetricRegistry.name(SessionManager.SESSIONS_METRIC_PREFIX, "deleted")).getCount());
   }
 
   @Test
@@ -280,7 +279,6 @@ public class TestSessionManager {
     verify(repository).getSessionData("1");
     verify(factory).build(sessionData);
     verify(session).doInvalidate(true);
-    assertEquals(1, metrics.meter(MetricRegistry.name(SessionManager.SESSIONS_METRIC_PREFIX, "deleted")).getCount());
   }
 
   @Test

--- a/session-replacement/src/test/java/com/amadeus/session/repository/redis/TestRedisConfiguration.java
+++ b/session-replacement/src/test/java/com/amadeus/session/repository/redis/TestRedisConfiguration.java
@@ -33,13 +33,23 @@ public class TestRedisConfiguration {
     assertEquals("SINGLE", configuration.clusterMode);
     assertEquals("localhost", configuration.server);
     assertEquals("6379", configuration.port);
-    assertEquals(ExpirationStrategy.NOTIF, configuration.strategy);
+    assertEquals(ExpirationStrategy.ZRANGE, configuration.strategy);
     assertEquals(new Integer(2000), configuration.timeout);
   }
 
   @Test
   public void testParseConfiguration() {
-	  sc.setProviderConfiguration("pool=400,timeout=5000,host=www.example.com,expiration=ZRANGE");
+    sc.setProviderConfiguration("pool=400,timeout=5000,host=www.example.com,expiration=NOTIF");
+    RedisConfiguration configuration = new RedisConfiguration(sc);
+    assertEquals("400", configuration.poolSize);
+    assertEquals("www.example.com", configuration.server);
+    assertEquals(ExpirationStrategy.NOTIF, configuration.strategy);
+    assertEquals(new Integer(5000), configuration.timeout);
+  }
+
+  @Test
+  public void testParseConfigurationSortedSet() {
+    sc.setProviderConfiguration("pool=400,timeout=5000,host=www.example.com,expiration=ZRANGE");
     RedisConfiguration configuration = new RedisConfiguration(sc);
     assertEquals("400", configuration.poolSize);
     assertEquals("www.example.com", configuration.server);

--- a/session-replacement/src/test/java/com/amadeus/session/repository/redis/TestSortedSetExpiration.java
+++ b/session-replacement/src/test/java/com/amadeus/session/repository/redis/TestSortedSetExpiration.java
@@ -58,6 +58,7 @@ public class TestSortedSetExpiration {
 
   @Test
   public void testSessionTouched() {
+    expiration.initPollingIntervals(300);
     expiration.sessionTouched(session);
     byte[] expectedKey = SafeEncoder.encode(SortedSetSessionExpirationManagement.ALLSESSIONS_KEY + "test");
     ArgumentCaptor<byte[]> captureExpireKey = ArgumentCaptor.forClass(byte[].class);

--- a/session-replacement/src/test/java/com/amadeus/session/repository/redis/TestSortedSetExpirationWithStickiness.java
+++ b/session-replacement/src/test/java/com/amadeus/session/repository/redis/TestSortedSetExpirationWithStickiness.java
@@ -60,6 +60,7 @@ public class TestSortedSetExpirationWithStickiness {
 
   @Test
   public void testSessionTouched() {
+    expiration.initPollingIntervals(300);
     expiration.sessionTouched(session);
     byte[] expectedKey = SafeEncoder.encode(SortedSetSessionExpirationManagement.ALLSESSIONS_KEY + "test");
     ArgumentCaptor<byte[]> captureExpireKey = ArgumentCaptor.forClass(byte[].class);

--- a/session-replacement/src/test/java/com/amadeus/session/servlet/it/ArqITSessionBinding.java
+++ b/session-replacement/src/test/java/com/amadeus/session/servlet/it/ArqITSessionBinding.java
@@ -1,0 +1,59 @@
+package com.amadeus.session.servlet.it;
+
+import static com.amadeus.session.servlet.it.Helpers.assertFirstLineEquals;
+import static com.amadeus.session.servlet.it.Helpers.callWebapp;
+import static com.amadeus.session.servlet.it.Helpers.setSessionCookie;
+import static com.amadeus.session.servlet.it.Helpers.url;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.amadeus.session.SessionConfiguration;
+
+@SuppressWarnings("javadoc")
+@RunWith(Arquillian.class)
+public class ArqITSessionBinding extends AbstractITSession {
+  @Deployment(testable = false, name="binding-param")
+  public static WebArchive startInitParam() {
+    return Helpers.createWebApp("binding-param.war").addClass(BindingServlet.class)
+        .setWebXML(new StringAsset(Descriptors.create(WebAppDescriptor.class).version("3.0")
+            .getOrCreateContextParam().paramName(SessionConfiguration.DEFAULT_SESSION_TIMEOUT).paramValue("2").up().exportAsString()));
+  }
+
+  
+  @RunAsClient
+  @Test
+  @OperateOnDeployment("binding-param")
+  public void testSessionDoesNotExpire(@ArquillianResource URL baseURL) throws IOException, InterruptedException {
+    URL urlTest = url(baseURL, "BindingServlet", "testSessionDoesNotExpire");
+    String originalCookie = callWebapp(urlTest);
+    await(1000);
+    HttpURLConnection connection = (HttpURLConnection) urlTest.openConnection();
+    setSessionCookie(connection, originalCookie);
+    connection.connect();
+    assertFirstLineEquals(connection, "Binding calls: 1:0");
+    await(2100);
+    connection = (HttpURLConnection) urlTest.openConnection();
+    setSessionCookie(connection, originalCookie);
+    connection.connect();
+    assertFirstLineEquals(connection, "Binding calls: 1:1");
+  }
+
+  // Wait for specified amount of milliseconds
+  private static void await(int millis) throws InterruptedException {
+    Thread.sleep(millis);
+  }
+}

--- a/session-replacement/src/test/java/com/amadeus/session/servlet/it/ArqITSessionExpire.java
+++ b/session-replacement/src/test/java/com/amadeus/session/servlet/it/ArqITSessionExpire.java
@@ -45,7 +45,6 @@ public class ArqITSessionExpire extends AbstractITSession {
 
   @Deployment(testable = false, name="never-expires")
   public static WebArchive startNeverExpires() {
-
     return Helpers.createWebApp("never-expires.war").addClass(SampleServlet.class)
         .setWebXML(new StringAsset(Descriptors.create(WebAppDescriptor.class).version("3.0")
             .getOrCreateContextParam().paramName(SessionConfiguration.DEFAULT_SESSION_TIMEOUT).paramValue("0").up().exportAsString()));

--- a/session-replacement/src/test/java/com/amadeus/session/servlet/it/BindingServlet.java
+++ b/session-replacement/src/test/java/com/amadeus/session/servlet/it/BindingServlet.java
@@ -1,0 +1,63 @@
+package com.amadeus.session.servlet.it;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSessionBindingListener;
+import javax.servlet.http.HttpSessionBindingEvent;
+
+/**
+ * Used for integration tests. Changes session id.
+ */
+@WebServlet("/BindingServlet")
+public class BindingServlet  extends BaseTestServlet {
+  private static final long serialVersionUID = 1L;
+
+  private static BindingListener myBinding = new BindingListener();
+
+  /**
+   * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse
+   *      response)
+   */
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+    log(request);
+    PrintWriter w = response.getWriter();
+    w.println("Binding calls: " + myBinding);
+    request.getSession(true).setAttribute("Binding", myBinding);
+    System.out.println(request.getSession().getId());
+    System.out.println(request.getSession().getId());
+    System.out.println(request.getSession().getId());
+    System.out.println(request.getSession().getId());
+    System.out.println(request.getSession().getId());
+    System.out.println(request.getSession().getId());
+    System.out.println(request.getSession().getId());
+    System.out.println(request.getSession().getId());
+    System.out.println(request.getSession().getId());
+    w.println("New value of attribute: " + request.getSession().getAttribute("Binding"));
+    w.println("Encoded url: " + response.encodeURL("/"));
+    w.append("Served at: ").append(request.getContextPath()).append(" ");
+  }
+
+  static class BindingListener implements HttpSessionBindingListener {
+      static int totalBounds;
+      static int totalUnbounds;
+      public void valueBound(HttpSessionBindingEvent event) {
+        totalBounds++;
+      }
+
+      public void valueUnbound(HttpSessionBindingEvent event) {
+        totalUnbounds++;
+      }
+
+      @Override
+      public String toString() {
+          return "" + totalBounds + ":" + totalUnbounds;
+      }
+  } 
+}


### PR DESCRIPTION
NOTIF expiration strategy is not working with Redis Cluster mode. This pull request replaces it with ZRANGE as default one.