### PR TITLE
Option to pass-in Password and SSL/TLS configuration for SINGLE and SENTINEL modes only

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -96,6 +96,11 @@ as Redis docker container that listens on dynamically assigned port.
 ```sh
 mvn verify -Predis-single
 ```
+or Redis (with password) Docker Container
+
+```sh
+mvn verify -Predis-single-secure
+```
 
 #### Redis Sentinel Tests
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -191,8 +191,18 @@ initialization parameter `com.amadeus.session.delegate.writer` to `true`.
 
 Redis configuration can be passed in arguments of the session agent:
 
+**In JAVA_OPTS**
 ```
--javagent:session-agent.jar=mode=SINGLE,expiration=ZRANGE,host=localhost
+-javagent:session-agent.jar=provider=redis,distributable=true
+-Dcom.amadeus.session.namespace=APPNAME
+-Dcom.amadeus.session.redis.mode=SINGLE
+-Dcom.amadeus.session.redis.port=6380
+-Dcom.amadeus.session.redis.ssl=true
+-Dcom.amadeus.session.redis.tls=[TLSv1, TLSv1.1, TLSv1.2]
+-Dcom.amadeus.session.redis.expiration=ZRANGE
+-Dcom.amadeus.session.sticky=false
+-Dcom.amadeus.session.redis.host=localhost
+-Dcom.amadeus.session.redis.password="password" 
 ```
 
 ### Session replacement servlet context configuration
@@ -239,6 +249,7 @@ For more details, see [redis keyspace notifications](http://redis.io/topics/noti
 
 When using single Redis instance or twemproxy, the only required configuration is host address
 of server and, when not using default port 6379, the Redis port. 
+Default ssl is false and password is optional.
 
 ### Redis Sentinel Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <version.jacoco>0.7.9</version.jacoco>
     <junit.version>4.12</junit.version>
     <powermock.version>1.6.5</powermock.version>

--- a/session-replacement/pom.xml
+++ b/session-replacement/pom.xml
@@ -324,6 +324,77 @@
       </build>
     </profile>
     <profile>
+      <id>redis-single-secure</id>
+      <properties>
+        <it.com.amadeus.session.redis.expiration>NOTIF</it.com.amadeus.session.redis.expiration>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <verbose>true</verbose>
+              <useColor>true</useColor>
+              <images>
+                <image>
+                  <name>${redis.image}</name>
+                  <alias>redis</alias>
+                  <run>
+                    <cmd>redis-server --requirepass password --notify-keyspace-events Ex --bind 0.0.0.0</cmd>
+                    <ports>
+                      <!-- Port mappings: Redis internal port will be dynamically mapped
+                        and this (random) port will be assigned to the maven variable ${redis.port}. -->
+                      <port>6379:6379</port>
+                    </ports>
+                    <wait>
+                      <!-- Wait for this in logs -->
+                      <log>The server is now ready</log>
+                      <!-- ... but at max 10 seconds -->
+                      <time>10000</time>
+                    </wait>
+                    <log>
+                      <enabled>true</enabled>
+                      <date>default</date>
+                    </log>
+                  </run>
+                </image>
+              </images>
+              <verbose>true</verbose>
+            </configuration>
+            <executions>
+              <execution>
+                <id>start</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>start</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>stop</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>stop</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <!-- Pass redis conf to tests ... -->
+                <com.amadeus.session.repository.conf>mode=SINGLE,port=6379,host=localhost,password=password</com.amadeus.session.repository.conf>
+                <com.amadeus.session.redis.expiration>${it.com.amadeus.session.redis.expiration}</com.amadeus.session.redis.expiration>
+                <redis.integration.tests>true</redis.integration.tests>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>redis-sentinel</id>
       <properties>
         <it.com.amadeus.session.redis.expiration>ZRANGE</it.com.amadeus.session.redis.expiration>

--- a/session-replacement/src/main/java/com/amadeus/session/repository/redis/JedisSessionRepositoryFactory.java
+++ b/session-replacement/src/main/java/com/amadeus/session/repository/redis/JedisSessionRepositoryFactory.java
@@ -1,8 +1,5 @@
 package com.amadeus.session.repository.redis;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.HostAndPort;
@@ -10,9 +7,10 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.JedisSentinelPool;
 
-import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Redis configuration is provided as a comma separated list with following
@@ -74,13 +72,12 @@ public class JedisSessionRepositoryFactory extends AbstractRedisSessionRepositor
 
     SSLSocketFactory sslSocketFactory = null;
     SSLParameters sslParameters = null;
-    HostnameVerifier hostnameVerifier = null;
 
-    if (config.useSSL){
+    if (config.useSSL) {
         sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
         sslParameters = new SSLParameters();
         sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
-        if(config.tls != null) {
+        if (config.tls != null) {
             sslParameters.setProtocols(config.tls);
         } else {
             //Enable all TLS (including weak TLSv1 and v1.1)
@@ -88,14 +85,13 @@ public class JedisSessionRepositoryFactory extends AbstractRedisSessionRepositor
         }
     }
 
-    logger.debug("with following - values poolConfig: " + poolConfig.toString() + ", " +
-          "config.server: " + config.server +
-          " port: " + port + ", " +
-          " config.timeout: " + config.timeout + ", " +
-          " config.password: " + config.password + ", " + //WARNING - Debug mode logs password.
-          " config.useSSL: " + config.useSSL);
+    //WARNING - Debug mode logs password.
+    logger.debug("With following configuration. poolConfig: `{}`, server: {}, port: {}, timeout: {}, password: {}, useSSL: {}",
+            poolConfig.toString(), config.server, port, config.timeout, config.password, config.useSSL);
 
-    return new JedisPoolFacade(new JedisPool(poolConfig, config.server, port, config.timeout, config.password, config.useSSL, sslSocketFactory, sslParameters, hostnameVerifier));
+
+
+    return new JedisPoolFacade(new JedisPool(poolConfig, config.server, port, config.timeout, config.password, config.useSSL, sslSocketFactory, sslParameters, null));
 
   }
 

--- a/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
+++ b/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
@@ -78,7 +78,7 @@ public class RedisConfiguration {
 
 
   /**
-   * System or configuration property that specifies Whether to use SSL or not.
+   * System or configuration property for TLS.
    *
    */
   public static final String REDIS_TLS = "com.amadeus.session.redis.tls";

--- a/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
+++ b/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
@@ -141,7 +141,7 @@ public class RedisConfiguration {
 
   String password;
 
-  boolean useSSL = false;
+  Boolean useSSL;
 
   String tls[];
 
@@ -173,11 +173,11 @@ public class RedisConfiguration {
     if (password == null) {
       password = conf.getAttribute(REDIS_PASSWORD, null);
     }
-    if (useSSL == false) {
-      useSSL = stringToBool(conf.getAttribute(REDIS_SSL, "false"));
+    if (useSSL == null) {
+      useSSL = Boolean.parseBoolean(conf.getAttribute(REDIS_SSL, "false"));
     }
-    if (tls == null ){
-        tls = tlsStringToArray(conf.getAttribute(REDIS_TLS, "TLSv1, TLSv1.1, TLSv1.2"));
+    if (tls == null ) {
+        tls = tlsStringToArray(conf.getAttribute(REDIS_TLS, "[TLSv1, TLSv1.1, TLSv1.2]"));
     }
     if (masterName == null) {
       masterName = conf.getAttribute(REDIS_MASTER_NAME, DEFAULT_REDIS_MASTER_NAME);
@@ -250,10 +250,10 @@ public class RedisConfiguration {
     } else if (arg.startsWith(PASSWORD_PROPERTY)){
       password = arg.substring(PASSWORD_PROPERTY.length());
     } else if (arg.startsWith(SSL_PROPERTY)){
-      useSSL = stringToBool(arg.substring(SSL_PROPERTY.length()));
+      useSSL = Boolean.parseBoolean(arg.substring(SSL_PROPERTY.length()).trim());
     } else if (arg.startsWith(TLS_PROPERTY) ) {
-       tls = tlsStringToArray(arg.substring(TLS_PROPERTY.length()));
-    }else if (arg.startsWith(MASTER_NAME_PROPERTY)) {
+      tls = tlsStringToArray(arg.substring(TLS_PROPERTY.length()));
+    } else if (arg.startsWith(MASTER_NAME_PROPERTY)) {
       masterName = arg.substring(MASTER_NAME_PROPERTY.length());
     } else if (arg.startsWith(EXPIRATION_PROPERTY)) {
       try {
@@ -321,14 +321,6 @@ public class RedisConfiguration {
               .map(String::trim)
               .toArray(String[]::new);
   }
-
-  /**
-   * Utility method for converting ssl config to boolean
-   */
-  private boolean stringToBool(String str) {
-    return str.trim().equalsIgnoreCase("true") ? true : false;
-  }
-
 
 
   /**

--- a/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
+++ b/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
@@ -174,10 +174,10 @@ public class RedisConfiguration {
       password = conf.getAttribute(REDIS_PASSWORD, null);
     }
     if (useSSL == null) {
-      useSSL = Boolean.parseBoolean(conf.getAttribute(REDIS_SSL, "false"));
+      useSSL = Boolean.parseBoolean(conf.getAttribute(REDIS_SSL, "false").trim());
     }
     if (tls == null ) {
-        tls = tlsStringToArray(conf.getAttribute(REDIS_TLS, "[TLSv1, TLSv1.1, TLSv1.2]"));
+      tls = tlsStringToArray(conf.getAttribute(REDIS_TLS, "[TLSv1, TLSv1.1, TLSv1.2]"));
     }
     if (masterName == null) {
       masterName = conf.getAttribute(REDIS_MASTER_NAME, DEFAULT_REDIS_MASTER_NAME);

--- a/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
+++ b/session-replacement/src/main/java/com/amadeus/session/repository/redis/RedisConfiguration.java
@@ -65,6 +65,26 @@ public class RedisConfiguration {
   public static final String REDIS_HOST = "com.amadeus.session.redis.host";
 
   /**
+   * System or configuration property that specifies the password
+   *
+   */
+  public static final String REDIS_PASSWORD = "com.amadeus.session.redis.password";
+
+  /**
+   * System or configuration property that specifies Whether to use SSL or not.
+   *
+   */
+  public static final String REDIS_SSL = "com.amadeus.session.redis.ssl";
+
+
+  /**
+   * System or configuration property that specifies Whether to use SSL or not.
+   *
+   */
+  public static final String REDIS_TLS = "com.amadeus.session.redis.tls";
+
+
+  /**
    * System or configuration property that specifies the size of the pool of redis connections.
    */
   public static final String REDIS_POOL_SIZE = "com.amadeus.session.redis.pool";
@@ -99,6 +119,12 @@ public class RedisConfiguration {
 
   static final String HOST_PROPERTY = "host=";
 
+  static final String PASSWORD_PROPERTY = "password=";
+
+  static final String SSL_PROPERTY = "ssl=";
+
+  static final String TLS_PROPERTY = "tls=";
+
   static final String REDIS_PORT_PROPERTY = "port=";
 
   static final String EXPIRATION_PROPERTY = "expiration=";
@@ -112,6 +138,12 @@ public class RedisConfiguration {
   String server;
 
   String port;
+
+  String password;
+
+  boolean useSSL = false;
+
+  String tls[];
 
   String poolSize;
 
@@ -138,6 +170,15 @@ public class RedisConfiguration {
   public RedisConfiguration(SessionConfiguration conf) {
     readConfigurationString(conf.getProviderConfiguration());
     serverAddress(conf);
+    if (password == null) {
+      password = conf.getAttribute(REDIS_PASSWORD, null);
+    }
+    if (useSSL == false) {
+      useSSL = stringToBool(conf.getAttribute(REDIS_SSL, "false"));
+    }
+    if (tls == null ){
+        tls = tlsStringToArray(conf.getAttribute(REDIS_TLS, "TLSv1, TLSv1.1, TLSv1.2"));
+    }
     if (masterName == null) {
       masterName = conf.getAttribute(REDIS_MASTER_NAME, DEFAULT_REDIS_MASTER_NAME);
     }
@@ -189,7 +230,8 @@ public class RedisConfiguration {
 
   private void readConfigurationString(String conf) {
     if (conf != null) {
-      String[] args = conf.split(",");
+      // Regex to separate comma outside square brackets.
+      String[] args = conf.split(",(?![^\\[]*[\\]])");
       for (String arg : args) {
         parseArgFromConfiguration(arg.trim());
       }
@@ -205,7 +247,13 @@ public class RedisConfiguration {
       clusterMode = arg.substring(CLUSTER_MODE_PROPERTY.length());
     } else if (arg.startsWith(HOST_PROPERTY)) {
       server = arg.substring(HOST_PROPERTY.length());
-    } else if (arg.startsWith(MASTER_NAME_PROPERTY)) {
+    } else if (arg.startsWith(PASSWORD_PROPERTY)){
+      password = arg.substring(PASSWORD_PROPERTY.length());
+    } else if (arg.startsWith(SSL_PROPERTY)){
+      useSSL = stringToBool(arg.substring(SSL_PROPERTY.length()));
+    } else if (arg.startsWith(TLS_PROPERTY) ) {
+       tls = tlsStringToArray(arg.substring(TLS_PROPERTY.length()));
+    }else if (arg.startsWith(MASTER_NAME_PROPERTY)) {
       masterName = arg.substring(MASTER_NAME_PROPERTY.length());
     } else if (arg.startsWith(EXPIRATION_PROPERTY)) {
       try {
@@ -259,6 +307,29 @@ public class RedisConfiguration {
       }
     }
   }
+
+  /**
+   * Utility method for converting TLS string to array, which will be used in SSL Parameters configuration.
+   * Example String passed in. tls=[TLSv1, TLSv1.1, TLSv1.2]
+   * Trim spaces and remove square brackets.
+   */
+  private String[] tlsStringToArray(String tlsStr) {
+      return  Arrays
+              .stream(tlsStr
+              .replace("[", "").replace("]", "")
+              .split(","))
+              .map(String::trim)
+              .toArray(String[]::new);
+  }
+
+  /**
+   * Utility method for converting ssl config to boolean
+   */
+  private boolean stringToBool(String str) {
+    return str.trim().equalsIgnoreCase("true") ? true : false;
+  }
+
+
 
   /**
    * Returns port to use either from server:port pair, or default port.

--- a/session-replacement/src/test/java/com/amadeus/session/repository/redis/TestRedisConfiguration.java
+++ b/session-replacement/src/test/java/com/amadeus/session/repository/redis/TestRedisConfiguration.java
@@ -1,5 +1,6 @@
 package com.amadeus.session.repository.redis;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -55,6 +56,23 @@ public class TestRedisConfiguration {
     assertEquals("www.example.com", configuration.server);
     assertEquals(ExpirationStrategy.ZRANGE, configuration.strategy);
     assertEquals(new Integer(5000), configuration.timeout);
+  }
+
+  @Test
+  public void testParseConfigurationPasswordAndSSLConfig() {
+
+    /**
+     * Note:
+     * Password - Yes, passwords can contain "=" to in them.
+     * TLS - Using Square brackets for TLS config. Not sure if there is a better way of defining multiple TLS.
+     */
+    sc.setProviderConfiguration("timeout=5000,host=www.example.com,password=Pa$$word=,ssl=true,tls=[TLSv1, TLSv1.1, TLSv1.2]");
+    RedisConfiguration configuration = new RedisConfiguration(sc);
+    assertEquals(new Integer(5000), configuration.timeout);
+    assertEquals("www.example.com", configuration.server);
+    assertEquals("Pa$$word=", configuration.password);
+    assertEquals(true, configuration.useSSL);
+    assertArrayEquals(new String[]{"TLSv1","TLSv1.1", "TLSv1.2"}, configuration.tls);
   }
 
   @Test


### PR DESCRIPTION
**Change Log**
* Updated JDK compiler version to `1.8`
* Adding additional parameters to pass-in password, SSL/TLS configuration for SINGLE and SENTINEL modes only.
* Updated the logic to split the Configuration String by comma outside square brackets only.
**For example**:
`host=www.example.com,password=Pa$$word=,ssl=true,tls=[TLSv1, TLSv1.1, TLSv1.2]`
will be split to
    ```
    host=www.example.com,
    password=Pa$$word=,
    ssl=true,
    tls=[TLSv1, TLSv1.1, TLSv1.2]
    ```
* Updates to Usage and Build documentation. (Note - Usage Redis configuration to pass-in host, expiration, etc., via session-agent.java etc was not working.)
* Updating JUnit Test case.
* Adding a new configuration to create redis-single docker instance with password to test passwords.

**TODO**
* Add password ability to Redis Cluster mode.